### PR TITLE
Add cmd to find changed services

### DIFF
--- a/cmd/changed_services.go
+++ b/cmd/changed_services.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/moveaxlab/dep-check/structure"
 	log "github.com/sirupsen/logrus"
@@ -26,12 +27,15 @@ var changedServicesCommand = &cobra.Command{
 
 		dependencies.ExpandDependencies(changedServices)
 
+		var services []string
 		for _, pkg := range changedServices.Enumerate() {
 			if pkg.Type() == structure.Service {
-				log.Infof("change detected in service %s", pkg)
-				fmt.Fprintln(os.Stdout, pkg.Path())
+				services = append(services, pkg.Name())
 			}
 		}
+	
+		log.Println("changes detected for services", services)
+		fmt.Println(strings.Join(services, " "))
 
 		return nil
 	},

--- a/cmd/changed_services.go
+++ b/cmd/changed_services.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/moveaxlab/dep-check/structure"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var changedServicesCommand = &cobra.Command{
+	Use:   "changed-services",
+	Short: "detect changed services from a git diff",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		baseStruct := structure.NewBaseStruct()
+
+		changedServices := baseStruct.GetChangedPackages(os.Stdin)
+
+		if changedServices.Contains(structure.RootPkg) {
+			log.Infof("change detected in root package")
+		}
+
+		dependencies := baseStruct.BuildPackageTree("./...").
+			ToDependencyTree()
+
+		dependencies.ExpandDependencies(changedServices)
+
+		for _, pkg := range changedServices.Enumerate() {
+			if pkg.Type() == structure.Service {
+				log.Infof("change detected in service %s", pkg)
+				fmt.Fprintln(os.Stdout, pkg.Path())
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(changedServicesCommand)
+}


### PR DESCRIPTION
This PR adds a new command to output all the packages tagged as services from a git diff. This is useful for our other CI/CD tool deploy1 in order to build and deploy only the affected services and not the entire repo.